### PR TITLE
adtk 0.6.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,15 +11,17 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
-  noarch: python
+  skip: True  # [py<35]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
   host:
     - pip
-    - python >=3.5
+    - python
+    - setuptools
+    - wheel
   run:
-    - python >=3.5
+    - python
     - pandas >=0.23
     - numpy >=1.15
     - matplotlib-base >=3.0
@@ -31,6 +33,10 @@ requirements:
 test:
   imports:
     - adtk
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/arundo/adtk
@@ -43,6 +49,8 @@ about:
     with unified APIs, as well as pipe classes that connect them together into 
     models. It also provides some functions to process and visualize 
     time series and anomaly events.
+  dev_url: https://github.com/arundo/adtk
+  doc_url: https://github.com/arundo/adtk
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,14 +16,15 @@ build:
 
 requirements:
   host:
-    - pip
     - python
+    - numpy
+    - pip
     - setuptools
     - wheel
   run:
     - python
     - pandas >=0.23
-    - numpy >=1.15
+    - {{ pin_compatible('numpy') }}
     - matplotlib-base >=3.0
     - scikit-learn >=0.20
     - statsmodels >=0.9

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - numpy >=1.15
     - matplotlib-base >=3.0
     - scikit-learn >=0.20
-    - statsmodels <0.11,>=0.9
+    - statsmodels >=0.9
     - packaging >=17.0
     - tabulate >=0.8
 


### PR DESCRIPTION
License: https://github.com/arundo/adtk/blob/develop/LICENSE
Changelog: 
Requirements: https://github.com/arundo/adtk/blob/v0.6.2/setup.cfg

Actions:
1. Skip `py<35`
2. Add `--no-deps`
3. Fix `python` pinning
4. Add fixes for `numpy`
5. Add `setuptools` & `wheel`
6. Fix pinning for `statsmodels >=0.9`
8. Add `pip check`
9. Add `doc_url` and `dev_url`